### PR TITLE
Update Faker requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     zip_safe=False,
     use_2to3=True,
     install_requires=[
-        'fake-factory',
+        'Faker>=0.7.0',
         'arrow',
         'click',
         'PyYAML',


### PR DESCRIPTION
While performing :
`from fake_mail_client.message import MessageFaker`

Error raises as follows :
`ImportError: The ``fake-factory`` package is now called ``Faker```

And found a fix from :
https://github.com/FactoryBoy/factory_boy/issues/334

Tried, and is now working fine.